### PR TITLE
Fixed incorrect dataset type setting in 6_potsdam config

### DIFF
--- a/configs/_base_/datasets/6_potsdam.py
+++ b/configs/_base_/datasets/6_potsdam.py
@@ -1,5 +1,5 @@
 # dataset settings
-dataset_type = 'PotsdamNoClutterDataset'
+dataset_type = 'PotsdamMMSEGDataset'
 data_root = 'data/6potsdam' #Dataset Crop 512 stride 256
 img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)


### PR DESCRIPTION
Found this bug while testing for the 6 class version of Potsdam (additional clutter class). Without it the results for this class do not appear in the test and I suspect they are not used in the metrics for the validation. 